### PR TITLE
Update hyperflex_cluster.py

### DIFF
--- a/intersight/models/hyperflex_cluster.py
+++ b/intersight/models/hyperflex_cluster.py
@@ -605,7 +605,7 @@ class HyperflexCluster(object):
         :param hypervisor_type: The hypervisor_type of this HyperflexCluster.
         :type: str
         """
-        allowed_values = ["Unknown", "HyperV", "ESXi"]
+        allowed_values = ["Unknown", "HyperV", "Hyper-V", "ESXi"]
         if hypervisor_type not in allowed_values:
             raise ValueError(
                 "Invalid value for `hypervisor_type` ({0}), must be one of {1}"


### PR DESCRIPTION
I came across a moid with the following:

      "HypervisorType": "Hyper-V",
      "HypervisorVersion": "Windows Server 2016",

hence I'm adding Hyper-V to the allowed_values list. I couldn't find other HyperV environments to check if the value is always Hyper-V or if it can be HyperV as well.